### PR TITLE
Store booleans in intersection_id_to_columns

### DIFF
--- a/pace/membership.py
+++ b/pace/membership.py
@@ -704,7 +704,8 @@ class Membership:
             # consistent with the constructor(s) from 'Format 1' csv files
             .rename(lambda x: "category@" + x, axis=1)
             .fillna(0.0)
-            .astype(int)
+            # Type is boolean (not int)
+            .astype(bool)
         )
         intersection_id_to_columns = mship_pivot.rename_axis("intersection_id")
 


### PR DESCRIPTION
from_membership_data_frame() originally used 0 and 1 to flag sets, which was wrong and made the set bar chart wrong (and maybe other visualizations). It now uses boolean flags, like the other setvis functions.