### PR TITLE
Don't create temporary directory in notebook workflow step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,4 @@ jobs:
       if: runner.os == 'Linux' && matrix.python-version == '3.8'
       run: |
         pip install -e '.[all]'
-        mkdir -p ../_notebook-output
         cd tests && bash check_notebooks.sh
-


### PR DESCRIPTION
No longer necessary since using `jupyter execute`.